### PR TITLE
fix: resolve CLI command for both linked / workspace and installed package

### DIFF
--- a/.github/workflows/publish-selected-package.yml
+++ b/.github/workflows/publish-selected-package.yml
@@ -69,6 +69,20 @@ jobs:
             fi
           fi
 
+      # Get PR description or last commit message for release body
+      - name: Set release body
+        id: release_body
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "body<<EOF" >> $GITHUB_OUTPUT
+            echo "${{ github.event.pull_request.body }}" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "body<<EOF" >> $GITHUB_OUTPUT
+            git log -1 --pretty=%B >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -77,7 +91,7 @@ jobs:
           body: |
             Release of ${{ env.RELEASE_NAME }}
 
-            ${{ steps.commit_message.outputs.message }}
+            ${{ steps.release_body.outputs.body }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/builder-rslib/package.json
+++ b/packages/builder-rslib/package.json
@@ -38,8 +38,8 @@
     "@mainset/toolkit-js": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/cli": "^0.1.0",
-    "@mainset/dev-stack-fe": "^0.1.0",
+    "@mainset/cli": "^0.1.1",
+    "@mainset/dev-stack-fe": "^0.1.1",
     "@mainset/toolkit-js": "^0.1.0"
   }
 }

--- a/packages/builder-rslib/package.json
+++ b/packages/builder-rslib/package.json
@@ -36,5 +36,10 @@
     "@mainset/cli": "workspace:^",
     "@mainset/dev-stack-fe": "workspace:^",
     "@mainset/toolkit-js": "workspace:^"
+  },
+  "peerDependencies": {
+    "@mainset/cli": "^0.1.0",
+    "@mainset/dev-stack-fe": "^0.1.0",
+    "@mainset/toolkit-js": "^0.1.0"
   }
 }

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -41,8 +41,8 @@
     "@mainset/toolkit-js": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/cli": "^0.1.0",
-    "@mainset/dev-stack-fe": "^0.1.0",
+    "@mainset/cli": "^0.1.1",
+    "@mainset/dev-stack-fe": "^0.1.1",
     "@mainset/toolkit-js": "^0.1.0"
   }
 }

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -39,5 +39,10 @@
     "@mainset/cli": "workspace:^",
     "@mainset/dev-stack-fe": "workspace:^",
     "@mainset/toolkit-js": "workspace:^"
+  },
+  "peerDependencies": {
+    "@mainset/cli": "^0.1.0",
+    "@mainset/dev-stack-fe": "^0.1.0",
+    "@mainset/toolkit-js": "^0.1.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A unified CLI tool for accelerating development, based on mainset vision of front-end infrastructure",
   "homepage": "https://github.com/mainset/dev-stack-fe/tree/main/packages/cli",
   "bugs": {
@@ -52,6 +52,6 @@
     "@types/node": "^24.0.3"
   },
   "peerDependencies": {
-    "@mainset/dev-stack-fe": "0.1.0"
+    "@mainset/dev-stack-fe": "^0.1.1"
   }
 }

--- a/packages/cli/src/commands/node-package.mts
+++ b/packages/cli/src/commands/node-package.mts
@@ -22,7 +22,7 @@ function registerNodePackageCommand(program: Command) {
     .requiredOption('-e, --exec <type>', 'Execution mode: build or watch')
     // .option('-b, --builder <builder>', 'Builder tool (default: rslib)', 'rslib')
     .option('-c, --config <path>', 'Path to config file', './rslib.config.mts')
-    .action(async (options) => {
+    .action((options) => {
       // Step 0: determinate command params
       const customRslibConfigPath = path.resolve(
         runtimePathById.root,
@@ -47,10 +47,10 @@ function registerNodePackageCommand(program: Command) {
 
           // Step 2: build source code
           console.log('\n📦 Compiling Source Code with Rslib ...');
-          await execRslibCLICommand(`build --config ${rslibConfigPath}`);
+          execRslibCLICommand(`build --config ${rslibConfigPath}`);
 
           // Step 3: build type only
-          await execTypeScriptCompileTypeOnly();
+          execTypeScriptCompileTypeOnly();
 
           console.log('\n✅ Build completed successfully\n');
         } catch (error) {
@@ -65,15 +65,10 @@ function registerNodePackageCommand(program: Command) {
           execPurgeDist();
 
           // Step 2: watch source code
-          await runRslibCLICommand([
-            'build',
-            '--config',
-            rslibConfigPath,
-            '--watch',
-          ]);
+          runRslibCLICommand(['build', '--config', rslibConfigPath, '--watch']);
 
           // Step 3: watch type only
-          await runTypeScriptCompileTypeOnly();
+          runTypeScriptCompileTypeOnly();
         } catch (error) {
           initProcessCatchErrorLogger('node-package', error, 'watch');
         }

--- a/packages/cli/src/commands/process-runner-chunks/rslib.chunk.mts
+++ b/packages/cli/src/commands/process-runner-chunks/rslib.chunk.mts
@@ -4,26 +4,25 @@ import {
   runStreamingCommand,
 } from '../../utils/index.mjs';
 
-async function getRslibCLICommandPath() {
-  const rslibCLICommandPath = await resolveHostPackageBinForCLICommandPath(
+function getRslibCLICommandPath() {
+  const rslibCLICommandPath = resolveHostPackageBinForCLICommandPath(
     '@mainset/builder-rslib',
-    '@rslib/core',
     'rslib',
   );
 
   return rslibCLICommandPath;
 }
 
-async function execRslibCLICommand(command: string) {
-  const rslibCLICommandPath = await getRslibCLICommandPath();
+function execRslibCLICommand(command: string) {
+  const rslibCLICommandPath = getRslibCLICommandPath();
 
-  return execImmediateCommand(`node ${rslibCLICommandPath} ${command}`);
+  return execImmediateCommand(`${rslibCLICommandPath} ${command}`);
 }
 
-async function runRslibCLICommand(commandParams: string[]) {
-  const rslibCLICommandPath = await getRslibCLICommandPath();
+function runRslibCLICommand(commandParams: string[]) {
+  const rslibCLICommandPath = getRslibCLICommandPath();
 
-  return runStreamingCommand('node', [rslibCLICommandPath, ...commandParams]);
+  return runStreamingCommand(rslibCLICommandPath, [...commandParams]);
 }
 
 export { execRslibCLICommand, runRslibCLICommand };

--- a/packages/cli/src/commands/process-runner-chunks/typescript.chunk.mts
+++ b/packages/cli/src/commands/process-runner-chunks/typescript.chunk.mts
@@ -9,10 +9,9 @@ import {
   runStreamingCommand,
 } from '../../utils/index.mjs';
 
-async function getTscCLICommandPath() {
-  const tscCLICommandPath = await resolveHostPackageBinForCLICommandPath(
+function getTscCLICommandPath() {
+  const tscCLICommandPath = resolveHostPackageBinForCLICommandPath(
     '@mainset/dev-stack-fe',
-    'typescript',
     'tsc',
   );
 
@@ -20,31 +19,26 @@ async function getTscCLICommandPath() {
 }
 
 // Source code
-async function execTypeScriptCompileSourceCode({
+function execTypeScriptCompileSourceCode({
   configPath,
 }: {
   configPath: string;
 }) {
-  const tscCLICommandPath = await getTscCLICommandPath();
+  const tscCLICommandPath = getTscCLICommandPath();
 
   console.log('\n📦 Compiling Source Code with TypeScript ...');
-  execImmediateCommand(`node ${tscCLICommandPath} --project ${configPath}`);
+  execImmediateCommand(`${tscCLICommandPath} --project ${configPath}`);
 }
 
-async function runTypeScriptCompileSourceCode({
+function runTypeScriptCompileSourceCode({
   configPath,
 }: {
   configPath: string;
 }) {
-  const tscCLICommandPath = await getTscCLICommandPath();
+  const tscCLICommandPath = getTscCLICommandPath();
 
   console.log('\n📝 Compiling .d.ts Types in watch mode ...');
-  runStreamingCommand('node', [
-    tscCLICommandPath,
-    '--project',
-    configPath,
-    '--watch',
-  ]);
+  runStreamingCommand(tscCLICommandPath, ['--project', configPath, '--watch']);
 }
 
 // Type only
@@ -59,25 +53,20 @@ function getTypeScriptTypeOnlyConfigPath() {
   };
 }
 
-async function execTypeScriptCompileTypeOnly() {
+function execTypeScriptCompileTypeOnly() {
   const { configPath } = getTypeScriptTypeOnlyConfigPath();
-  const tscCLICommandPath = await getTscCLICommandPath();
+  const tscCLICommandPath = getTscCLICommandPath();
 
   console.log('\n📝 Compiling .d.ts Types in build mode ...');
-  execImmediateCommand(`node ${tscCLICommandPath} --project ${configPath}`);
+  execImmediateCommand(`${tscCLICommandPath} --project ${configPath}`);
 }
 
-async function runTypeScriptCompileTypeOnly() {
+function runTypeScriptCompileTypeOnly() {
   const { configPath } = getTypeScriptTypeOnlyConfigPath();
-  const tscCLICommandPath = await getTscCLICommandPath();
+  const tscCLICommandPath = getTscCLICommandPath();
 
   console.log('\n📝 Compiling .d.ts Types in watch mode ...');
-  runStreamingCommand('node', [
-    tscCLICommandPath,
-    '--project',
-    configPath,
-    '--watch',
-  ]);
+  runStreamingCommand(tscCLICommandPath, ['--project', configPath, '--watch']);
 }
 
 export {

--- a/packages/cli/src/commands/source-code.mts
+++ b/packages/cli/src/commands/source-code.mts
@@ -21,7 +21,7 @@ function registerSourceCodeCommand(program: Command) {
     .requiredOption('-e, --exec <type>', 'Execution mode: compile or watch')
     // .option('-b, --builder <builder>', 'Compiler tool (default: tsc)', 'tsc')
     .option('-c, --config <path>', 'Path to config file', './tsconfig.json')
-    .action(async (options) => {
+    .action((options) => {
       // Step 0: determinate command params
       const typeScriptSourceCodeConfigPath = path.join(
         runtimePathById.root,
@@ -37,12 +37,12 @@ function registerSourceCodeCommand(program: Command) {
           execPurgeDist();
 
           // Step 2: compile source code
-          await execTypeScriptCompileSourceCode({
+          execTypeScriptCompileSourceCode({
             configPath: typeScriptSourceCodeConfigPath,
           });
 
           // Step 3: compile type only
-          await execTypeScriptCompileTypeOnly();
+          execTypeScriptCompileTypeOnly();
 
           console.log('\n✅ Build completed successfully\n');
         } catch (error) {
@@ -57,12 +57,12 @@ function registerSourceCodeCommand(program: Command) {
           execPurgeDist();
 
           // Step 2: watch source code
-          await runTypeScriptCompileSourceCode({
+          runTypeScriptCompileSourceCode({
             configPath: typeScriptSourceCodeConfigPath,
           });
 
           // Step 3: watch type only
-          await runTypeScriptCompileTypeOnly();
+          runTypeScriptCompileTypeOnly();
         } catch (error) {
           initProcessCatchErrorLogger('source-code', error, 'watch');
         }

--- a/packages/cli/src/commands/web-app.mts
+++ b/packages/cli/src/commands/web-app.mts
@@ -37,7 +37,7 @@ function registerWebAppCommand(program: Command) {
       'Serve mode: ssr or csr (default: ssr)',
       'ssr',
     )
-    .action(async (options) => {
+    .action((options) => {
       // Step 0: determinate command params
       const customWebpackConfigPath = path.resolve(
         runtimePathById.root,
@@ -45,12 +45,10 @@ function registerWebAppCommand(program: Command) {
       );
 
       // Webpack paths
-      const webpackCLICommandPath =
-        await resolveHostPackageBinForCLICommandPath(
-          '@mainset/bundler-webpack',
-          'webpack',
-          'webpack',
-        );
+      const webpackCLICommandPath = resolveHostPackageBinForCLICommandPath(
+        '@mainset/bundler-webpack',
+        'webpack',
+      );
       const webpackSSRConfigPath = fs.existsSync(customWebpackConfigPath)
         ? customWebpackConfigPath
         : path.resolve(
@@ -79,12 +77,12 @@ function registerWebAppCommand(program: Command) {
             // Step 2: build:ssr-webapp source code
             console.log('\n📦 Compiling SSR WebApp with Webpack ...');
             execImmediateCommand(
-              `node ${webpackCLICommandPath} --config ${webpackSSRConfigPath}`,
+              `${webpackCLICommandPath} --config ${webpackSSRConfigPath}`,
             );
 
             // Step 3: build:ssr-server source code
             console.log('\n📦 Compiling SSR Server with Rslib ...');
-            await execRslibCLICommand(`build --config ${rslibSSRConfigPath}`);
+            execRslibCLICommand(`build --config ${rslibSSRConfigPath}`);
 
             console.log('\n✅ SSR Build completed successfully\n');
           } else {
@@ -103,7 +101,7 @@ function registerWebAppCommand(program: Command) {
             // Step 2: build:csr-webapp source code
             console.log('\n📦 Compiling CSR WebApp with Webpack ...');
             execImmediateCommand(
-              `node ${webpackCLICommandPath} --config ${webpackCSRConfigPath}`,
+              `${webpackCLICommandPath} --config ${webpackCSRConfigPath}`,
             );
 
             console.log('\n✅ CSR Build completed successfully\n');
@@ -129,7 +127,7 @@ function registerWebAppCommand(program: Command) {
             );
 
             // Step 1: watch:ssr-server start ssr server
-            await runRslibCLICommand([
+            runRslibCLICommand([
               'build',
               '--config',
               rslibSSRConfigPath,
@@ -137,8 +135,7 @@ function registerWebAppCommand(program: Command) {
             ]);
 
             // Step 2: watch:ssr-webapp source code of web app
-            runStreamingCommand('node', [
-              webpackCLICommandPath,
+            runStreamingCommand(webpackCLICommandPath, [
               '--config',
               webpackSSRConfigPath,
               '--watch',
@@ -164,8 +161,7 @@ function registerWebAppCommand(program: Command) {
                 );
 
             // Step 1: watch:csr-server / start:csr-server source code
-            runStreamingCommand('node', [
-              webpackCLICommandPath,
+            runStreamingCommand(webpackCLICommandPath, [
               'serve',
               '--config',
               webpackDevServerConfigPath,

--- a/packages/cli/src/commands/web-app.mts
+++ b/packages/cli/src/commands/web-app.mts
@@ -153,13 +153,6 @@ function registerWebAppCommand(program: Command) {
             ]);
           } else {
             // ========== [Serve] CSR mode ==========
-
-            const webpackDevServerCLICommandPath =
-              await resolveHostPackageBinForCLICommandPath(
-                '@mainset/bundler-webpack',
-                'webpack-dev-server',
-              );
-
             const webpackDevServerConfigPath = fs.existsSync(
               customWebpackConfigPath,
             )
@@ -172,7 +165,8 @@ function registerWebAppCommand(program: Command) {
 
             // Step 1: watch:csr-server / start:csr-server source code
             runStreamingCommand('node', [
-              webpackDevServerCLICommandPath,
+              webpackCLICommandPath,
+              'serve',
               '--config',
               webpackDevServerConfigPath,
               '--open',

--- a/packages/cli/src/services/express-base-app/express-base-app.mts
+++ b/packages/cli/src/services/express-base-app/express-base-app.mts
@@ -63,7 +63,7 @@ class ExpressBaseApp {
   // }
 
   // ========== Public ==========
-  public async startListening() {
+  public startListening() {
     this.app.listen(this.listenPort, async () => {
       const packageJson = await import(
         path.resolve(runtimePathById.root, 'package.json'),

--- a/packages/dev-stack-fe/package.json
+++ b/packages/dev-stack-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/dev-stack-fe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Modern dev stack for front-end infrastructure for mainset projects",
   "homepage": "https://github.com/mainset/dev-stack-fe/tree/main/packages/dev-stack-fe",
   "bugs": {

--- a/packages/dev-stack-fe/src/eslint/eslint.xo.fragment.mjs
+++ b/packages/dev-stack-fe/src/eslint/eslint.xo.fragment.mjs
@@ -5,6 +5,15 @@ import { defineConfig } from 'eslint/config';
 // https://github.com/xojs/xo/issues/798#issuecomment-2892108379
 const xoFileted = [xo[0], xo[2]];
 
-const eslintXoFragment = defineConfig([...xoFileted]);
+const eslintXoFragment = defineConfig([
+  ...xoFileted,
+
+  {
+    rules: {
+      // override: {eslint-config-xo}
+      'capitalized-comments': 'off',
+    },
+  },
+]);
 
 export { eslintXoFragment };

--- a/packages/toolkit-js/package.json
+++ b/packages/toolkit-js/package.json
@@ -32,6 +32,6 @@
     "@mainset/dev-stack-fe": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/dev-stack-fe": "0.1.0"
+    "@mainset/dev-stack-fe": "^0.1.1"
   }
 }


### PR DESCRIPTION
- override `capitalized-comments` rule of `eslint-config-xo` 
- run `ms-cli` for all kinds of packages: installed / linked / workspace  by executing `resolveHostPackageBinForCLICommandPath` based on `.bin` folder of node_modules` (instead of getting `"bin"` path from `package.json` as package is NOT available for package installed from registry
- correct `resolveHostPackageNodeModulesPath` for package install from registry - a regular string with package name should be returned