### PR TITLE
fix: resolve CLI command for both linked / workspace and installed package

### DIFF
--- a/packages/builder-rslib/package.json
+++ b/packages/builder-rslib/package.json
@@ -38,8 +38,8 @@
     "@mainset/toolkit-js": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/cli": "^0.1.0",
-    "@mainset/dev-stack-fe": "^0.1.0",
+    "@mainset/cli": "^0.1.1",
+    "@mainset/dev-stack-fe": "^0.1.1",
     "@mainset/toolkit-js": "^0.1.0"
   }
 }

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -41,8 +41,8 @@
     "@mainset/toolkit-js": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/cli": "^0.1.0",
-    "@mainset/dev-stack-fe": "^0.1.0",
+    "@mainset/cli": "^0.1.1",
+    "@mainset/dev-stack-fe": "^0.1.1",
     "@mainset/toolkit-js": "^0.1.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A unified CLI tool for accelerating development, based on mainset vision of front-end infrastructure",
   "homepage": "https://github.com/mainset/dev-stack-fe/tree/main/packages/cli",
   "bugs": {
@@ -52,6 +52,6 @@
     "@types/node": "^24.0.3"
   },
   "peerDependencies": {
-    "@mainset/dev-stack-fe": "0.1.0"
+    "@mainset/dev-stack-fe": "^0.1.1"
   }
 }

--- a/packages/dev-stack-fe/package.json
+++ b/packages/dev-stack-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/dev-stack-fe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Modern dev stack for front-end infrastructure for mainset projects",
   "homepage": "https://github.com/mainset/dev-stack-fe/tree/main/packages/dev-stack-fe",
   "bugs": {

--- a/packages/toolkit-js/package.json
+++ b/packages/toolkit-js/package.json
@@ -32,6 +32,6 @@
     "@mainset/dev-stack-fe": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/dev-stack-fe": "0.1.0"
+    "@mainset/dev-stack-fe": "^0.1.1"
   }
 }


### PR DESCRIPTION
- override `capitalized-comments` rule of `eslint-config-xo` 
- run `ms-cli` for all kinds of packages: installed / linked / workspace  by executing `resolveHostPackageBinForCLICommandPath` based on `.bin` folder of node_modules` (instead of getting `"bin"` path from `package.json` as package is NOT available for package installed from registry
- correct `resolveHostPackageNodeModulesPath` for package install from registry - a regular string with package name should be returned