### PR TITLE
release: bundler-webpack@0.2.0 cli@0.2.0

### DIFF
--- a/packages/builder-rslib/package.json
+++ b/packages/builder-rslib/package.json
@@ -38,7 +38,7 @@
     "@mainset/toolkit-js": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/cli": "^0.1.1",
+    "@mainset/cli": "^0.2.0",
     "@mainset/dev-stack-fe": "^0.1.1",
     "@mainset/toolkit-js": "^0.1.0"
   }

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/bundler-webpack",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Bundler for web apps",
   "homepage": "https://github.com/mainset/dev-stack-fe/tree/main/packages/bundler-webpack",
   "bugs": {
@@ -54,7 +54,7 @@
     "@mainset/toolkit-js": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/cli": "^0.1.1",
+    "@mainset/cli": "^0.2.0",
     "@mainset/dev-stack-fe": "^0.1.1",
     "@mainset/toolkit-js": "^0.1.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/cli",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A unified CLI tool for accelerating development, based on mainset vision of front-end infrastructure",
   "homepage": "https://github.com/mainset/dev-stack-fe/tree/main/packages/cli",
   "bugs": {


### PR DESCRIPTION
1. [feat: bundler-webpack support global css and css modules loader](https://github.com/mainset/dev-stack-fe/commit/6511951c627c98a186b960a03d1f41ccfbda5c14)
    - support styles loading from `/src/styles/global.scss` entry point or by `import * as styles from './*.module.scss`

2. [feat: support bundling of public folder content into dist](https://github.com/mainset/dev-stack-fe/commit/de325814bfe539a44dadd92a4eab4701a61cae37)
    - all files placed in `./public` folder - will be copied to `./dist`

4. [feat: introduce --serveMode support for serve-static and make ssr as default one](https://github.com/mainset/dev-stack-fe/commit/65b1c7e9cab57f652460a7e52de3a5e1cdef60ec)
    - split `pnpm run serve:static` for: `pnpm run serve:csr` and `pnpm run serve:ssr`
  
5. [feat: do not use rslib while bundling app with webpack](https://github.com/mainset/dev-stack-fe/commit/1ff7572476d62989ffc42709f2aa3417198e8296)
    - bundle the SSR server with webpack (instead of rslib) so the HTML class will match the generated hash

6. [fix: run streaming in sync, as node server requires webpack app to be compiled fist](https://github.com/mainset/dev-stack-fe/commit/47347901a9c74c2eb8b22ac9e53e3f545afa1080)
    - fixed crash on first run of `pnpm run dev` in SSR mode, when webpack assets weren't ready beforethe  node server launched