### PR TITLE
release: cli@0.2.1

### DIFF
--- a/packages/builder-rslib/package.json
+++ b/packages/builder-rslib/package.json
@@ -38,7 +38,7 @@
     "@mainset/toolkit-js": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/cli": "^0.2.0",
+    "@mainset/cli": "^0.2.1",
     "@mainset/dev-stack-fe": "^0.1.1",
     "@mainset/toolkit-js": "^0.1.0"
   }

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -54,7 +54,7 @@
     "@mainset/toolkit-js": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/cli": "^0.2.0",
+    "@mainset/cli": "^0.2.1",
     "@mainset/dev-stack-fe": "^0.1.1",
     "@mainset/toolkit-js": "^0.1.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A unified CLI tool for accelerating development, based on mainset vision of front-end infrastructure",
   "homepage": "https://github.com/mainset/dev-stack-fe/tree/main/packages/cli",
   "bugs": {


### PR DESCRIPTION
1. [fix: runtime resolver does not work with --frozen-lockfile](https://github.com/mainset/dev-stack-fe/commit/b47fa025865d7ffc92911d5f6292e0814fef2acb)
    - cli commands have been working only when packages have been installed without `pnpm-lock.json` existing. If `pnpm-lock.json` has been created and only the `node_modules` has been removed, the cli сommands was failing. So `pnpm install --frozen-lockfile`, which is required for Docker, wasn't working.