### PR TITLE
release: dev-stack-fe@0.1.2

### DIFF
--- a/packages/builder-rslib/package.json
+++ b/packages/builder-rslib/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@mainset/cli": "^0.2.1",
-    "@mainset/dev-stack-fe": "^0.1.1",
+    "@mainset/dev-stack-fe": "^0.1.2",
     "@mainset/toolkit-js": "^0.1.0"
   }
 }

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "@mainset/cli": "^0.2.1",
-    "@mainset/dev-stack-fe": "^0.1.1",
+    "@mainset/dev-stack-fe": "^0.1.2",
     "@mainset/toolkit-js": "^0.1.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,6 @@
     "@types/node": "^24.0.3"
   },
   "peerDependencies": {
-    "@mainset/dev-stack-fe": "^0.1.1"
+    "@mainset/dev-stack-fe": "^0.1.2"
   }
 }

--- a/packages/dev-stack-fe/package.json
+++ b/packages/dev-stack-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/dev-stack-fe",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Modern dev stack for front-end infrastructure for mainset projects",
   "homepage": "https://github.com/mainset/dev-stack-fe/tree/main/packages/dev-stack-fe",
   "bugs": {

--- a/packages/toolkit-js/package.json
+++ b/packages/toolkit-js/package.json
@@ -32,6 +32,6 @@
     "@mainset/dev-stack-fe": "workspace:^"
   },
   "peerDependencies": {
-    "@mainset/dev-stack-fe": "^0.1.1"
+    "@mainset/dev-stack-fe": "^0.1.2"
   }
 }


### PR DESCRIPTION
1. [fix: usage of dev-stack-fe configs in final project](https://github.com/mainset/dev-stack-fe/commit/05eb75b2f1d259c3da75c425d596a8e56900901c)
    - commitlint and prittier shared configs path for plugins not resolved after they installed from registry